### PR TITLE
Markeer DK WUS als 'Uit te faseren' binnen Digikoppeling Architectuur

### DIFF
--- a/6_dk_koppelvlakstandaarden_en_voorschriften.md
+++ b/6_dk_koppelvlakstandaarden_en_voorschriften.md
@@ -99,14 +99,14 @@ Voor het beschrijven van DK-Rest API's is het gebruik van OAS verplicht. Op [[Pa
 
 ## WUS
 
-> **In het kader van Life-Cycle Management van de Koppelvlakstandaarden krijgt het DK WUS Koppelvlak de status "Uit te faseren" als volgt:**
-> 
-> | Koppelvlak Standaard | Status         | Toelichting                                     | Einde Ondersteuning | Einde Gebruik |
-> |----------------------|----------------|-------------------------------------------------|---------------------|---------------|
-> | Digikoppeling WUS    | Uit te faseren | Het DK WUS koppelvlak dient te worden uit gefaseerd | 01-01-2028          | 01-01-2033    |
-> 
-> - Na 01-01-2028 is gebruik nog toegestaan voor legacy applicaties tot 01-01-2033 — echter de organisatie is zelf verantwoordelijk voor functionele en security updates.
-
+<p class="note" title="Uitfasering">
+  In het kader van Life-Cycle Management wordt het DK WUS-koppelvlak gemarkeerd als "Uit te faseren".
+  <ul>
+    <li>Einde ondersteuning: 01-01-2028</li>
+    <li>Einde gebruik: 01-01-2033</li>
+    <li>Legacygebruik is toegestaan tot 01-01-2033, maar organisaties zijn na 2028 zelf verantwoordelijk voor functionele en security-updates.</li>
+  </ul>
+</p>
 
 ### WUS familie van standaarden
 

--- a/6_dk_koppelvlakstandaarden_en_voorschriften.md
+++ b/6_dk_koppelvlakstandaarden_en_voorschriften.md
@@ -99,6 +99,15 @@ Voor het beschrijven van DK-Rest API's is het gebruik van OAS verplicht. Op [[Pa
 
 ## WUS
 
+> **In het kader van Life-Cycle Management van de Koppelvlakstandaarden krijgt het DK WUS Koppelvlak de status "Uit te faseren" als volgt:**
+> 
+> | Koppelvlak Standaard | Status         | Toelichting                                     | Einde Ondersteuning | Einde Gebruik |
+> |----------------------|----------------|-------------------------------------------------|---------------------|---------------|
+> | Digikoppeling WUS    | Uit te faseren | Het DK WUS koppelvlak dient te worden uit gefaseerd | 01-01-2028          | 01-01-2033    |
+> 
+> - Na 01-01-2028 is gebruik nog toegestaan voor legacy applicaties tot 01-01-2033 — echter de organisatie is zelf verantwoordelijk voor functionele en security updates.
+
+
 ### WUS familie van standaarden
 
 Digikoppeling maakt gebruik van een familie van standaarden die we binnen Digikoppeling de naam “WUS” geven. Deze familie van standaarden is gebaseerd op webservice standaarden uit de profielen van de OASIS “Web Services – Basic Reliable and Secure Profiles” Technical Committee (WS-BRSP)<sup>[27](#f27)</sup>. De naam WUS staat voor WSDL, UDDI en SOAP, drie belangrijke deelstandaarden. Hoewel Digikoppeling geen gebruik van UDDI maakt is deze term inmiddels gebruikelijk.

--- a/6_dk_koppelvlakstandaarden_en_voorschriften.md
+++ b/6_dk_koppelvlakstandaarden_en_voorschriften.md
@@ -99,14 +99,14 @@ Voor het beschrijven van DK-Rest API's is het gebruik van OAS verplicht. Op [[Pa
 
 ## WUS
 
-<p class="note" title="Uitfasering">
-  In het kader van Life-Cycle Management wordt het DK WUS-koppelvlak gemarkeerd als "Uit te faseren".
+<div class="note" title="Uitfasering">
+  <p>In het kader van Life-Cycle Management wordt het DK WUS-koppelvlak gemarkeerd als "Uit te faseren".</p>
   <ul>
     <li>Einde ondersteuning: 01-01-2028</li>
     <li>Einde gebruik: 01-01-2033</li>
     <li>Legacygebruik is toegestaan tot 01-01-2033, maar organisaties zijn na 2028 zelf verantwoordelijk voor functionele en security-updates.</li>
   </ul>
-</p>
+</div>
 
 ### WUS familie van standaarden
 


### PR DESCRIPTION
In het kader van Life-Cycle Management wordt het DK WUS koppelvlak gemarkeerd als 'Uit te faseren'.
- Einde ondersteuning: 01-01-2028
- Einde gebruik: 01-01-2033
- Legacygebruik is toegestaan tot 01-01-2033, maar organisaties zijn na 2028 zelf verantwoordelijk voor functionele en security-updates.