### PR TITLE
Beheer: Fix broken link & versienummering

### DIFF
--- a/js/config.mjs
+++ b/js/config.mjs
@@ -42,7 +42,7 @@ loadRespecWithConfiguration({
     ],
   github: "https://github.com/Logius-standaarden/Digikoppeling-Architectuur",
   previousPublishDate: "2024-01-16",
-  previousPublishVersion: "2.0.3",
+  previousPublishVersion: "2.0.2",
   pubDomain: "dk",
   publishDate: "2025-01-30",
   publishVersion: "2.1.0",

--- a/js/config.mjs
+++ b/js/config.mjs
@@ -42,7 +42,7 @@ loadRespecWithConfiguration({
     ],
   github: "https://github.com/Logius-standaarden/Digikoppeling-Architectuur",
   previousPublishDate: "2024-01-16",
-  previousPublishVersion: "2.0.2",
+  previousPublishVersion: "2.1.0",
   pubDomain: "dk",
   publishDate: "2025-01-30",
   publishVersion: "2.1.0",


### PR DESCRIPTION
In de laatste werkversie van het document en PDF wordt bij vorige versie 2.0.3 getoond. Dit klopt niet en leidt ook terecht naar een 404 error. Volgens https://github.com/Logius-standaarden/publicatie is de juiste vorige versie 2.0.2