### PR TITLE
Actualiseer CPA register link

### DIFF
--- a/8_dk_voorzieningen.md
+++ b/8_dk_voorzieningen.md
@@ -59,6 +59,6 @@ Het CPA Register ondersteunt partijen bij het maken van een CPA (Collaboration P
 
 - Het biedt zekerheid dat beide partijen dezelfde instellingen gebruiken.
 
-De wijze waarop een CPA wordt toegepast staat beschreven in Digikoppeling Best Practices ebMS2. Het CPA Register is beschreven in de Gebruikershandleiding. Het CPA register is te vinden op [https://cparegister.minvenj.nl](https://cparegister.minvenj.nl)
+De wijze waarop een CPA wordt toegepast staat beschreven in Digikoppeling Best Practices ebMS2. Het CPA Register is beschreven in de Gebruikershandleiding. Het CPA register is te vinden op [https://cparegister.nl](https://cparegister.nl)
 
 <br><sup><a name="f29"><dfn>29</dfn></a>: *Digikoppeling Best Practices ebMS*</sup

--- a/8_dk_voorzieningen.md
+++ b/8_dk_voorzieningen.md
@@ -59,6 +59,6 @@ Het CPA Register ondersteunt partijen bij het maken van een CPA (Collaboration P
 
 - Het biedt zekerheid dat beide partijen dezelfde instellingen gebruiken.
 
-De wijze waarop een CPA wordt toegepast staat beschreven in Digikoppeling Best Practices ebMS2. Het CPA Register is beschreven in de Gebruikershandleiding. Het CPA register is te vinden op [https://cparegister.nl](https://cparegister.nl)
+De wijze waarop een CPA wordt toegepast staat beschreven in Digikoppeling Best Practices ebMS2. Het CPA Register is beschreven in de Gebruikershandleiding. Het CPA register is te vinden op <https://cparegister.nl>.
 
 <br><sup><a name="f29"><dfn>29</dfn></a>: *Digikoppeling Best Practices ebMS*</sup

--- a/8_dk_voorzieningen.md
+++ b/8_dk_voorzieningen.md
@@ -61,4 +61,4 @@ Het CPA Register ondersteunt partijen bij het maken van een CPA (Collaboration P
 
 De wijze waarop een CPA wordt toegepast staat beschreven in Digikoppeling Best Practices ebMS2. Het CPA Register is beschreven in de Gebruikershandleiding. Het CPA register is te vinden op <https://cparegister.nl>.
 
-<br><sup><a name="f29"><dfn>29</dfn></a>: *Digikoppeling Best Practices ebMS*</sup
+<br><sup><a name="f29"><dfn>29</dfn></a>: *Digikoppeling Best Practices ebMS*</sup>


### PR DESCRIPTION
De actuele en primaire link voor het CPA register volgens justid is: https://cparegister.nl